### PR TITLE
Fixing multiple instances bug (each instance has the same username/pass)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ This will create a `convertLead(id)` method on the service. The provided functio
 9. Expose request & response objects
 10. Add option to create 'client.createResource' vs 'client.resource.create'
 11. Wrap Rester's default action method (post, get, etc) to make it easier to send the body & query params
+12. Upsert mode - Some API's use POST for create & update. In this case for all updates you need to create a custom update function so would be nice to have way to handle this automatically (1. All updates, 2. single resources)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stallion",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Simple way to create clients for your REST based services in Node",
   "main": "lib/stallion.js",
   "scripts": {

--- a/src/stallion.js
+++ b/src/stallion.js
@@ -24,7 +24,6 @@ var actionsMap = {
   delete: 'del'
 };
 
-
 class Stallion {
 
 
@@ -35,21 +34,32 @@ class Stallion {
    */
   constructor(config) {
 
-    // Configure Restler
-    var restler_config = {
-      baseURL: config.baseUrl
-    };
-
     // Create the restler API
     var api = this.buildApi(config);
 
-    var service = restler.service(default_init, restler_config, api);
-        service.api = Object.keys(api);
-        service.resources = this.objectsToResources(config);
-    // TODO: this right
-        //service.resources = objects.map(x => { return x.toLowerCase() });
 
-    return service;
+
+    // Can't use multilple instances of Reslter services
+    //
+    // Because each instance shares the defaults and the only way to set
+    // the username & password is to use the defaults each instance will
+    // actually be the same
+    //
+    // So instead when we create another instance of a Stallion service
+    // we'll actually create a seperate instance of a Restler service
+    var OurService = function(username, password) {
+      var restler_defaults = { baseURL: config.baseUrl };
+      var RestlerService = restler.service(default_init, restler_defaults, api);
+
+      return new RestlerService(username, password);
+    };
+
+    OurService.api = Object.keys(api);
+    OurService.resources = this.objectsToResources(config);
+        // TODO: this right
+        //OurService.resources = objects.map(x => { return x.toLowerCase() });
+
+    return OurService;
   }
 
 

--- a/test/stallion.spec.js
+++ b/test/stallion.spec.js
@@ -72,6 +72,24 @@ describe('Instantiate a service', function(){
     Service.resources.should.include.members(['users', 'companies', 'tasks']);
   });
 
+  describe('When creating multiples instances of a service', function() {
+    var client2;
+    var other_user = 'different_username';
+
+    before(function() {
+      client2 = new Service(other_user, pass);
+    });
+
+    // Restler's service will share the username/password across multiple
+    // instances so we need to create a new service for each instance
+    // of a service we want to create
+    it('each service has their own username & password', function() {
+      client.defaults.username.should.eq(user);
+      client2.defaults.username.should.eq(other_user);
+    });
+  });
+
+
   describe('When using object shortcut declaration', function() {
 
     it('Creates all CRUD methods when shortcut declaration is "crudpl"', function() {


### PR DESCRIPTION
Apparently Reslter's service functionality cannot handle multiple instances correctly.

In Restler the only way to set the username/password for the service is in the defaults.
But the defaults is a static property so it's shared across all instances of the service.

Guess it's time to move away from Restler. Best alternative?